### PR TITLE
chore: allow newer packaging versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ from setuptools import setup
 
 setup(
     name='PyPowerFlex',
-    version='1.6.0',
+    version='1.6.1',
     description='Python library for Dell PowerFlex',
     author='Ansible Team at Dell',
     author_email='ansible.team@dell.com',
     install_requires=[
-        'packaging==20.4',
+        'packaging>=20.4',
         'requests>=2.23.0',
     ],
     packages=[


### PR DESCRIPTION
First off, thanks for this project!

It didn't jump out at me why there would need to be pin for packaging==20.4, and I've run into a situation where I can't use this module in an ansible venv that includes ansible-lint==6.14.2.  It requires packaging>=21.3.

If there's anything you'd like me to change, don't hesitate to ask.