### PR TITLE
Fix SP get_sdss to return correct data

### DIFF
--- a/PyPowerFlex/objects/storage_pool.py
+++ b/PyPowerFlex/objects/storage_pool.py
@@ -162,9 +162,14 @@ class StoragePool(base_client.EntityRequest):
                                     'SpSds',
                                     filter_fields,
                                     fields=('sdsId',))
+        sds_id_list = [sds['sdsId'] for sds in sdss_ids]
         if filter_fields:
-            filter_fields.update({'id': sdss_ids})
-        return Sds(self.token, self.configuration).get(filter_fields, fields)
+            filter_fields.update({'id': sds_id_list})
+            filter_fields.pop('sdsId', None)
+        else:
+            filter_fields = {'id': sds_id_list}
+        return Sds(self.token, self.configuration).get(
+            filter_fields=filter_fields, fields=fields)
 
     def get_volumes(self, storage_pool_id, filter_fields=None, fields=None):
         """Get related PowerFlex volumes for storage pool.


### PR DESCRIPTION
Fixes #22 
Issue 1 - Attribute error when passing fields option to get_sdss
  Fix is to pass filter_fields and fields by name vs position
Issue 2 - get_sdss returns ALL sds in the system vs limited to SP
  Fix is to properly format filter_fields to match how Sds.get() expects
  when filtering.
Issue 3 - If filter_fields is passed to get_sdss, no SDS are returned
  Fix is to pop off sdsIds before creating the SDS objects