### PR TITLE
Address pep-0625

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 from setuptools import setup
 
 setup(
-    name='PyPowerFlex',
+    name='pypowerflex',
     version='1.14.0',
     description='Python library for Dell PowerFlex',
     author='Ansible Team at Dell',


### PR DESCRIPTION
To be compliant with [pep-0625](https://peps.python.org/pep-0625/), sdist name should be modified in format.