### PR TITLE
Remove query metrics from snapshot_policy

### DIFF
--- a/PyPowerFlex/objects/gen2/snapshot_policy.py
+++ b/PyPowerFlex/objects/gen2/snapshot_policy.py
@@ -107,16 +107,6 @@ class SnapshotPolicy(SnapshotPolicyGen1):
 
         return self.get(entity_id=snapshot_policy_id)
 
-    def query_snapshot_policy_metrics(self, snapshot_policy_id, metrics=None):
-        """Query PowerFlex Metrics for snapshot policy.
-        TODO TTHE make sure this API is valid after new dev build is ready
-
-        :type snapshot_policy_id: str
-        :type metrics: list|tuple
-        :rtype: dict
-        """
-        return self.query_metrics('snapshot_policy', [snapshot_policy_id], metrics)
-
     def get_statistics(self, snapshot_policy_id, fields=None):
         """Get PowerFlex Snapshot Policy Statistics not supported in PowerFlex 5.x.
 

--- a/tests/gen2/test_snapshot_policy.py
+++ b/tests/gen2/test_snapshot_policy.py
@@ -56,9 +56,6 @@ class TestSnapshotPolicyClient(PyPowerFlexTestCase):
                     {},
                 f'/instances/SnapshotPolicy::{self.fake_policy_id}/action/resumeSnapshotPolicy':
                     {},
-                '/dtapi/rest/v1/metrics/query': {
-                    self.fake_policy_id: {'numOfpypowerflexVols': 1}
-                },
             },
             self.RESPONSE_MODE.Invalid: {
                 '/types/SnapshotPolicy/instances':
@@ -221,23 +218,6 @@ class TestSnapshotPolicyClient(PyPowerFlexTestCase):
             self.assertRaises(exceptions.PowerFlexClientException,
                               self.client.snapshot_policy.resume,
                               self.fake_policy_id)
-
-    def test_snapshot_policy_query_metrics(self):
-        """
-        Test snapshot policy query selected metrics.
-        """
-        ret = self.client.snapshot_policy.query_snapshot_policy_metrics(self.fake_policy_id)
-        assert ret.get(self.fake_policy_id).get("numOfpypowerflexVols") == 1
-
-    def test_snapshot_policy_query_metrics_bad_status(self):
-        """
-        Test snapshot policy query selected metrics with bad status.
-        """
-        with self.http_response_mode(self.RESPONSE_MODE.BadStatus):
-            self.assertRaises(
-                exceptions.PowerFlexClientException,
-                self.client.snapshot_policy.query_snapshot_policy_metrics,
-                self.fake_policy_id)
 
     def test_snapshot_policy_query_selected_statistics_not_supported(self):
         """


### PR DESCRIPTION
Remove query metrics from snapshot_policy:
Snapshot_policy resource type is not supported by metrics/query REST Api since there are no metrics for this resource type. 